### PR TITLE
feat: Add content summarization feature

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "turndown": "^7.2.0",
       },
       "devDependencies": {
+        "@types/chrome": "^0.1.22",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@wxt-dev/module-react": "^1.1.3",
@@ -202,6 +203,8 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
+
+    "@types/chrome": ["@types/chrome@0.1.22", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-5uXbw/3V+Pdu9BaoTvudvutITxeIiC0CK5WhQr8lzEhAQ70lTpe5ebnoai9iQrqWjhIa3qynYhKV0NN0MKv4qA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -43,6 +43,25 @@ function calculateContentStats(content: string): ContentStats {
   };
 }
 
+// Function to generate a simple summary
+function summarizeContent(content: string, sentenceCount = 3): string {
+  if (!content) {
+    return "Not enough content to summarize.";
+  }
+
+  // A simple sentence tokenizer that handles various endings.
+  const sentences = content.match(/[^.!?\n]+[.!?\n]+/g) || [];
+
+  if (sentences.length === 0) {
+    // Fallback for content without clear sentence endings
+    return content.length > 250 ? content.substring(0, 250) + '...' : content;
+  }
+
+  const summary = sentences.slice(0, sentenceCount).join(' ').trim();
+
+  return summary || "Could not generate a summary.";
+}
+
 interface CrawledData {
   url: string;
   title: string;
@@ -166,6 +185,11 @@ export default defineBackground(() => {
         }
         const result = `Content preview ready (${exportFormat.toUpperCase()} format)`;
         sendResponse({ result, preview: previewContent });
+
+      } else if (type === 'summarize') {
+        // Use the plain text content for summarization
+        const summary = summarizeContent(content);
+        sendResponse({ result: summary });
       }
     }
     else if (request.action === 'startCrawl') {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -11,10 +11,10 @@ export default defineContentScript({
         const documentClone = document.cloneNode(true) as Document;
         const article = new Readability(documentClone).parse();
 
-        if (article) {
+        if (article && article.content) {
           const markdown = turndownService.turndown(article.content);
-          sendResponse({ 
-            markdown: markdown, 
+          sendResponse({
+            markdown: markdown,
             title: article.title, 
             content: article.textContent,
             html: article.content 

--- a/jules-scratch/verification/verify_summarize_feature.py
+++ b/jules-scratch/verification/verify_summarize_feature.py
@@ -1,0 +1,60 @@
+import asyncio
+from playwright.async_api import async_playwright
+import os
+
+async def main():
+    # Path to the extension
+    extension_path = os.path.abspath('.output/chrome-mv3')
+    user_data_dir = '/tmp/test-user-data-dir'
+
+    # Launch browser with extension
+    async with async_playwright() as p:
+        browser_context = await p.chromium.launch_persistent_context(
+            user_data_dir,
+            headless=True,
+            args=[
+                f'--disable-extensions-except={extension_path}',
+                f'--load-extension={extension_path}',
+            ]
+        )
+
+        try:
+            # Get the extension's service worker
+            service_worker = None
+            for sw in browser_context.service_workers:
+                if sw.url.startswith("chrome-extension://"):
+                    service_worker = sw
+                    break
+            if not service_worker:
+                service_worker = await browser_context.wait_for_event("serviceworker", timeout=60000)
+
+            extension_id = service_worker.url.split('/')[2]
+
+            # Test on a sample blog page
+            page = await browser_context.new_page()
+            await page.goto('https://surgegraph.io/content/sample-blog-post', wait_until='load', timeout=60000)
+
+            # Open the popup
+            popup_page = await browser_context.new_page()
+            await popup_page.goto(f'chrome-extension://{extension_id}/popup.html')
+
+            # Wait for the popup to load
+            await popup_page.wait_for_selector('#action-select', timeout=10000)
+
+            # Interact with the popup
+            await popup_page.select_option('#action-select', 'summarize')
+            await popup_page.click('.primary-button')
+
+            # Wait for the result to be displayed
+            await popup_page.wait_for_selector('.result-box p', timeout=15000)
+
+            # Take a screenshot
+            screenshot_path = 'jules-scratch/verification/summary_verification.png'
+            await popup_page.screenshot(path=screenshot_path)
+            print(f"Screenshot saved to {screenshot_path}")
+
+        finally:
+            await browser_context.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "turndown": "^7.2.0"
   },
   "devDependencies": {
+    "@types/chrome": "^0.1.22",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
     "@wxt-dev/module-react": "^1.1.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["chrome"]
   }
 }


### PR DESCRIPTION
This commit introduces a new "Summarize" feature to the PageScribe Chrome extension.

Key changes include:
- A `summarizeContent` function has been added to `entrypoints/background.ts` to generate a simple summary of the page's text content.
- The message listener in `entrypoints/background.ts` has been updated to handle the new `summarize` action.
- The UI in `entrypoints/popup/App.tsx` has been modified to include a "Summarize" option in the action dropdown.
- Resolved several TypeScript compilation errors by adding `@types/chrome` and refactoring error handling to be compatible with the `wxt` framework's promise-based APIs.