### PR TITLE
Refactor content processing logic to utils module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,8 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@wxt-dev/module-react": "^1.1.3",
-        "typescript": "^5.8.3",
+        "bun-types": "^1.3.10",
+        "typescript": "^5.9.3",
         "wxt": "^0.20.6",
       },
     },
@@ -312,6 +313,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -6,9 +6,8 @@ import keyword_extractor from 'keyword-extractor';
 // @ts-ignore
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
 
+import { summarizeContent, calculateContentStats, SummaryLength, SummaryFormat } from '../utils/content';
 
-type SummaryLength = 'short' | 'medium' | 'long';
-type SummaryFormat = 'paragraph' | 'bullets';
 
 interface HistoryItem {
   type: 'keywords';
@@ -17,125 +16,7 @@ interface HistoryItem {
   timestamp: number;
 }
 
-interface ContentStats {
-  wordCount: number;
-  charCount: number;
-  readingTime: number; // in minutes
-  paragraphs: number;
-}
-
-// Regular expressions moved to module scope for performance
-const MARKDOWN_SYMBOLS_REGEX = /[#*_`~\[\]()]/g;
-const IMAGES_REGEX = /!\[.*?\]\(.*?\)/g;
-const LINKS_REGEX = /\[.*?\]\(.*?\)/g;
-const CODE_BLOCKS_REGEX = /```[\s\S]*?```/g;
-const INLINE_CODE_REGEX = /`[^`]*`/g;
-const WORDS_SPLIT_REGEX = /\s+/;
-const PARAGRAPHS_SPLIT_REGEX = /\n\s*\n/;
-const SENTENCE_TOKENIZER_REGEX = /[^.!?\n]+[.!?\n]+/g;
 const FILENAME_SANITIZE_REGEX = /[\\/:":*?<>|]/g;
-
-// Function to calculate content statistics
-function calculateContentStats(content: string): ContentStats {
-  // Remove markdown syntax for more accurate counting
-  const plainText = content
-    .replace(MARKDOWN_SYMBOLS_REGEX, '') // Remove markdown symbols
-    .replace(IMAGES_REGEX, '') // Remove images
-    .replace(LINKS_REGEX, '') // Remove links
-    .replace(CODE_BLOCKS_REGEX, '') // Remove code blocks
-    .replace(INLINE_CODE_REGEX, '') // Remove inline code
-    .trim();
-
-  const words = plainText.split(WORDS_SPLIT_REGEX).filter(word => word.length > 0);
-  const wordCount = words.length;
-  const charCount = plainText.length;
-  
-  // Average reading speed is 200-250 words per minute, we'll use 225
-  const readingTime = Math.ceil(wordCount / 225);
-  
-  // Count paragraphs (split by double newlines)
-  const paragraphs = content.split(PARAGRAPHS_SPLIT_REGEX).filter(p => p.trim().length > 0).length;
-
-  return {
-    wordCount,
-    charCount,
-    readingTime: Math.max(1, readingTime), // Minimum 1 minute
-    paragraphs
-  };
-}
-
-// Expanded stop words list for better summarization
-const STOP_WORDS = new Set([
-  'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and', 'any', 'are', 'as', 'at',
-  'be', 'because', 'been', 'before', 'being', 'below', 'between', 'both', 'but', 'by',
-  'can', 'did', 'do', 'does', 'doing', 'don', 'down', 'during',
-  'each', 'few', 'for', 'from', 'further',
-  'had', 'has', 'have', 'having', 'he', 'her', 'here', 'hers', 'herself', 'him', 'himself', 'his', 'how',
-  'i', 'if', 'in', 'into', 'is', 'it', 'its', 'itself',
-  'just', 'me', 'more', 'most', 'my', 'myself',
-  'no', 'nor', 'not', 'now',
-  'of', 'off', 'on', 'once', 'only', 'or', 'other', 'our', 'ours', 'ourselves', 'out', 'over', 'own',
-  's', 'same', 'she', 'should', 'so', 'some', 'such',
-  't', 'than', 'that', 'the', 'their', 'theirs', 'them', 'themselves', 'then', 'there', 'these', 'they', 'this', 'those', 'through', 'to', 'too',
-  'under', 'until', 'up',
-  'very',
-  'was', 'we', 'were', 'what', 'when', 'where', 'which', 'while', 'who', 'whom', 'why', 'will', 'with',
-  'you', 'your', 'yours', 'yourself', 'yourselves'
-]);
-
-// Function to generate a smarter summary using sentence scoring
-function summarizeContent(content: string, sentenceCount = 3): string {
-  if (!content) return "Not enough content to summarize.";
-
-  // A simple sentence tokenizer that handles various endings.
-  const sentences = content.match(SENTENCE_TOKENIZER_REGEX) || [];
-
-  // Fallback if regex fails to split properly (e.g. no punctuation)
-  if (sentences.length === 0) {
-     return content.length > 300 ? content.substring(0, 300) + '...' : content;
-  }
-
-  if (sentences.length <= sentenceCount) {
-    return content;
-  }
-
-  // 2. Tokenize and calculate word frequencies
-  const wordFreq: Record<string, number> = {};
-  const words = content.toLowerCase().match(/\b\w+\b/g) || [];
-
-  words.forEach(word => {
-    if (!STOP_WORDS.has(word) && word.length > 2) {
-      wordFreq[word] = (wordFreq[word] || 0) + 1;
-    }
-  });
-
-  // 3. Score sentences based on word importance
-  const sentenceScores = sentences.map((sentence, index) => {
-    const sentenceWords = sentence.toLowerCase().match(/\b\w+\b/g) || [];
-    let score = 0;
-    sentenceWords.forEach(word => {
-      if (wordFreq[word]) {
-        score += wordFreq[word];
-      }
-    });
-
-    // Normalize by length (square root) to favor informative but not excessively long sentences
-    if (sentenceWords.length > 0) {
-        score = score / Math.pow(sentenceWords.length, 0.5);
-    }
-
-    return { sentence, score, index };
-  });
-
-  // 4. Sort by score (descending) and pick top N
-  sentenceScores.sort((a, b) => b.score - a.score);
-  const topSentences = sentenceScores.slice(0, sentenceCount);
-
-  // 5. Reorder by original index to maintain flow
-  topSentences.sort((a, b) => a.index - b.index);
-
-  return topSentences.map(s => s.sentence.trim()).join(' ');
-}
 
 interface CrawledData {
   url: string;
@@ -249,12 +130,7 @@ export default defineBackground(() => {
         } else if (request.action === 'processText') {
           const { type, content, title, summaryLength, summaryFormat } = request;
           if (type === 'summarize') {
-            // Adjust sentence count based on summaryLength
-            let count = 3;
-            if (summaryLength === 'short') count = 2;
-            if (summaryLength === 'long') count = 7;
-
-            const summary = summarizeContent(content, count);
+            const summary = summarizeContent(content, summaryLength, summaryFormat);
             sendResponse({ result: summary });
           } else if (type === 'keywords') {
             const keywords = keyword_extractor.extract(content, {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
     "@wxt-dev/module-react": "^1.1.3",
-    "typescript": "^5.8.3",
+    "bun-types": "^1.3.10",
+    "typescript": "^5.9.3",
     "wxt": "^0.20.6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "types": ["chrome"]
+    "types": ["chrome", "bun-types"]
   }
 }

--- a/utils/content.test.ts
+++ b/utils/content.test.ts
@@ -1,0 +1,99 @@
+import { expect, test, describe } from 'bun:test';
+import { calculateContentStats, summarizeContent, SummaryLength, SummaryFormat } from './content';
+
+describe('Content Utils', () => {
+  describe('calculateContentStats', () => {
+    test('should correctly count words and characters', () => {
+      const text = 'Hello world. This is a test.';
+      const stats = calculateContentStats(text);
+      expect(stats.wordCount).toBe(6);
+      expect(stats.charCount).toBe(text.length);
+    });
+
+    test('should handle markdown syntax', () => {
+      const text = '# Hello **world**. This is a `test`.';
+      const stats = calculateContentStats(text);
+      expect(stats.wordCount).toBe(6); // Markdown symbols should be stripped
+    });
+
+    test('should calculate reading time', () => {
+        // 225 words should be 1 minute
+        const words = Array(225).fill('word').join(' ');
+        const stats = calculateContentStats(words);
+        expect(stats.readingTime).toBe(1);
+
+        // 450 words should be 2 minutes
+        const moreWords = Array(451).fill('word').join(' ');
+        const moreStats = calculateContentStats(moreWords);
+        expect(moreStats.readingTime).toBe(3); // ceil(451/225) = 3
+    });
+
+    test('should count paragraphs', () => {
+        const text = 'Para 1.\n\nPara 2.\n\nPara 3.';
+        const stats = calculateContentStats(text);
+        expect(stats.paragraphs).toBe(3);
+    });
+  });
+
+  describe('summarizeContent', () => {
+    const longText = `
+      This is the first sentence.
+      This is the second sentence.
+      This is the third sentence.
+      This is the fourth sentence.
+      This is the fifth sentence.
+      This is the sixth sentence.
+      This is the seventh sentence.
+      This is the eighth sentence.
+    `;
+
+    test('should handle empty content', () => {
+      expect(summarizeContent('')).toBe('Not enough content to summarize.');
+    });
+
+    test('should return original content if short enough', () => {
+       const text = 'Just one sentence.';
+       expect(summarizeContent(text)).toBe(text);
+    });
+
+    test('should respect length parameter (short)', () => {
+        // 'short' maps to 2 sentences
+        const summary = summarizeContent(longText, 'short');
+        const sentences = summary.match(/[^.!?\n]+[.!?\n]+/g) || [];
+        expect(sentences.length).toBeLessThanOrEqual(2);
+    });
+
+    test('should respect length parameter (medium)', () => {
+        // 'medium' maps to 3 sentences
+        const summary = summarizeContent(longText, 'medium');
+        const sentences = summary.match(/[^.!?\n]+[.!?\n]+/g) || [];
+        expect(sentences.length).toBeLessThanOrEqual(3);
+    });
+
+     test('should respect length parameter (long)', () => {
+        // 'long' maps to 7 sentences
+        const summary = summarizeContent(longText, 'long');
+        const sentences = summary.match(/[^.!?\n]+[.!?\n]+/g) || [];
+        expect(sentences.length).toBeLessThanOrEqual(7);
+    });
+
+    test('should respect numeric length parameter', () => {
+        const summary = summarizeContent(longText, 4);
+        const sentences = summary.match(/[^.!?\n]+[.!?\n]+/g) || [];
+        expect(sentences.length).toBeLessThanOrEqual(4);
+    });
+
+    test('should format as bullets', () => {
+        const summary = summarizeContent(longText, 'short', 'bullets');
+        expect(summary).toContain('- ');
+        expect(summary.split('\n').length).toBeGreaterThan(1);
+    });
+
+    test('should format as paragraph', () => {
+        const summary = summarizeContent(longText, 'short', 'paragraph');
+        expect(summary).not.toContain('- ');
+        // Paragraph format joins with spaces
+        expect(summary).not.toContain('\n-');
+    });
+  });
+});

--- a/utils/content.ts
+++ b/utils/content.ts
@@ -1,0 +1,136 @@
+export type SummaryLength = 'short' | 'medium' | 'long';
+export type SummaryFormat = 'paragraph' | 'bullets';
+
+export interface ContentStats {
+  wordCount: number;
+  charCount: number;
+  readingTime: number; // in minutes
+  paragraphs: number;
+}
+
+// Regular expressions moved to module scope for performance
+const MARKDOWN_SYMBOLS_REGEX = /[#*_`~\[\]()]/g;
+const IMAGES_REGEX = /!\[.*?\]\(.*?\)/g;
+const LINKS_REGEX = /\[.*?\]\(.*?\)/g;
+const CODE_BLOCKS_REGEX = /```[\s\S]*?```/g;
+const INLINE_CODE_REGEX = /`[^`]*`/g;
+const WORDS_SPLIT_REGEX = /\s+/;
+const PARAGRAPHS_SPLIT_REGEX = /\n\s*\n/;
+const SENTENCE_TOKENIZER_REGEX = /[^.!?\n]+[.!?\n]+/g;
+
+// Function to calculate content statistics
+export function calculateContentStats(content: string): ContentStats {
+  // Remove markdown syntax for more accurate counting
+  const plainText = content
+    .replace(MARKDOWN_SYMBOLS_REGEX, '') // Remove markdown symbols
+    .replace(IMAGES_REGEX, '') // Remove images
+    .replace(LINKS_REGEX, '') // Remove links
+    .replace(CODE_BLOCKS_REGEX, '') // Remove code blocks
+    .replace(INLINE_CODE_REGEX, '') // Remove inline code
+    .trim();
+
+  const words = plainText.split(WORDS_SPLIT_REGEX).filter(word => word.length > 0);
+  const wordCount = words.length;
+  const charCount = plainText.length;
+
+  // Average reading speed is 200-250 words per minute, we'll use 225
+  const readingTime = Math.ceil(wordCount / 225);
+
+  // Count paragraphs (split by double newlines)
+  const paragraphs = content.split(PARAGRAPHS_SPLIT_REGEX).filter(p => p.trim().length > 0).length;
+
+  return {
+    wordCount,
+    charCount,
+    readingTime: Math.max(1, readingTime), // Minimum 1 minute
+    paragraphs
+  };
+}
+
+// Expanded stop words list for better summarization
+const STOP_WORDS = new Set([
+  'a', 'about', 'above', 'after', 'again', 'against', 'all', 'am', 'an', 'and', 'any', 'are', 'as', 'at',
+  'be', 'because', 'been', 'before', 'being', 'below', 'between', 'both', 'but', 'by',
+  'can', 'did', 'do', 'does', 'doing', 'don', 'down', 'during',
+  'each', 'few', 'for', 'from', 'further',
+  'had', 'has', 'have', 'having', 'he', 'her', 'here', 'hers', 'herself', 'him', 'himself', 'his', 'how',
+  'i', 'if', 'in', 'into', 'is', 'it', 'its', 'itself',
+  'just', 'me', 'more', 'most', 'my', 'myself',
+  'no', 'nor', 'not', 'now',
+  'of', 'off', 'on', 'once', 'only', 'or', 'other', 'our', 'ours', 'ourselves', 'out', 'over', 'own',
+  's', 'same', 'she', 'should', 'so', 'some', 'such',
+  't', 'than', 'that', 'the', 'their', 'theirs', 'them', 'themselves', 'then', 'there', 'these', 'they', 'this', 'those', 'through', 'to', 'too',
+  'under', 'until', 'up',
+  'very',
+  'was', 'we', 'were', 'what', 'when', 'where', 'which', 'while', 'who', 'whom', 'why', 'will', 'with',
+  'you', 'your', 'yours', 'yourself', 'yourselves'
+]);
+
+// Function to generate a smarter summary using sentence scoring
+export function summarizeContent(content: string, length: SummaryLength | number = 'medium', format: SummaryFormat = 'paragraph'): string {
+  if (!content) return "Not enough content to summarize.";
+
+  let sentenceCount = 3;
+  if (typeof length === 'number') {
+    sentenceCount = length;
+  } else {
+    if (length === 'short') sentenceCount = 2;
+    if (length === 'long') sentenceCount = 7;
+  }
+
+  // A simple sentence tokenizer that handles various endings.
+  const sentences = content.match(SENTENCE_TOKENIZER_REGEX) || [];
+
+  // Fallback if regex fails to split properly (e.g. no punctuation)
+  if (sentences.length === 0) {
+     return content.length > 300 ? content.substring(0, 300) + '...' : content;
+  }
+
+  if (sentences.length <= sentenceCount) {
+    if (format === 'bullets') {
+        return sentences.map(s => `- ${s.trim()}`).join('\n');
+    }
+    return content;
+  }
+
+  // 2. Tokenize and calculate word frequencies
+  const wordFreq: Record<string, number> = {};
+  const words = content.toLowerCase().match(/\b\w+\b/g) || [];
+
+  words.forEach(word => {
+    if (!STOP_WORDS.has(word) && word.length > 2) {
+      wordFreq[word] = (wordFreq[word] || 0) + 1;
+    }
+  });
+
+  // 3. Score sentences based on word importance
+  const sentenceScores = sentences.map((sentence, index) => {
+    const sentenceWords = sentence.toLowerCase().match(/\b\w+\b/g) || [];
+    let score = 0;
+    sentenceWords.forEach(word => {
+      if (wordFreq[word]) {
+        score += wordFreq[word];
+      }
+    });
+
+    // Normalize by length (square root) to favor informative but not excessively long sentences
+    if (sentenceWords.length > 0) {
+        score = score / Math.pow(sentenceWords.length, 0.5);
+    }
+
+    return { sentence, score, index };
+  });
+
+  // 4. Sort by score (descending) and pick top N
+  sentenceScores.sort((a, b) => b.score - a.score);
+  const topSentences = sentenceScores.slice(0, sentenceCount);
+
+  // 5. Reorder by original index to maintain flow
+  topSentences.sort((a, b) => a.index - b.index);
+
+  if (format === 'bullets') {
+    return topSentences.map(s => `- ${s.sentence.trim()}`).join('\n');
+  }
+
+  return topSentences.map(s => s.sentence.trim()).join(' ');
+}


### PR DESCRIPTION
Refactored `summarizeContent` and `calculateContentStats` into a new `utils/content.ts` module.

🎯 **What:**
- Created `utils/content.ts` to centralize content processing logic.
- Moved regex constants, `STOP_WORDS`, `ContentStats`, `SummaryLength`, and `SummaryFormat` to `utils/content.ts`.
- Refactored `summarizeContent` to accept `SummaryLength` and `SummaryFormat` directly, encapsulating the logic for sentence count mapping and formatting.
- Updated `entrypoints/background.ts` to use the new utility functions.
- Added comprehensive unit tests in `utils/content.test.ts`.

💡 **Why:**
- Improves maintainability by decoupling business logic from the background script.
- Fixes the code health issue where `summarizeContent` signature did not match its usage.
- Enables reuse of content processing logic across different parts of the extension (e.g., popup or content scripts).
- Adds test coverage for core functionality.

✅ **Verification:**
- Ran `bun test utils/content.test.ts` - All tests passed.
- Ran `bun run compile` - No TypeScript errors.

---
*PR created automatically by Jules for task [2812300952369957635](https://jules.google.com/task/2812300952369957635) started by @amafjarkasi*